### PR TITLE
Improve plot responsiveness

### DIFF
--- a/src/components/VisualizationComponent/VisualizationAComponent.jsx
+++ b/src/components/VisualizationComponent/VisualizationAComponent.jsx
@@ -1,33 +1,30 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Plot from "react-plotly.js";
-import { useState } from "react";
 import s from "./visualizationcomponent.module.css";
+import useWindowDimensions from "../../hooks/useWindowDimensions";
 
 const VisualizationAComponent = ({ data }) => {
+    const { width } = useWindowDimensions();
+    const isMobile = width <= 768;
+
     const [legendPosition, setLegendPosition] = useState({ orientation: "v", x: 1.05, y: 1 });
 
     useEffect(() => {
-        const updateLegend = () => {
-            const isMobile = window.innerWidth <= 768;
-            setLegendPosition(isMobile
+        setLegendPosition(
+            isMobile
                 ? {
                       orientation: "h",
                       x: 0.5,
                       y: -0.3,
-                      xanchor: "center"
+                      xanchor: "center",
                   }
                 : {
                       orientation: "v",
                       x: 1.05,
-                      y: 1
-                  });
-        };
-    
-        updateLegend(); // одразу встановити
-        window.addEventListener("resize", updateLegend);
-    
-        return () => window.removeEventListener("resize", updateLegend);
-    }, []);
+                      y: 1,
+                  }
+        );
+    }, [isMobile]);
     
 
 
@@ -63,12 +60,27 @@ const VisualizationAComponent = ({ data }) => {
                             },
                         ]}
                         layout={{
-                            title: "Візуалізація A-скану",
-                            xaxis: { title: "Час (µs)" },
-                            yaxis: { title: "Напруга (mV)" },
+                            title: {
+                                text: "Візуалізація A-скану",
+                                font: { size: isMobile ? 14 : 16 },
+                            },
+                            xaxis: {
+                                title: {
+                                    text: "Час (µs)",
+                                    font: { size: isMobile ? 12 : 14 },
+                                },
+                                tickfont: { size: isMobile ? 10 : 12 },
+                            },
+                            yaxis: {
+                                title: {
+                                    text: "Напруга (mV)",
+                                    font: { size: isMobile ? 12 : 14 },
+                                },
+                                tickfont: { size: isMobile ? 10 : 12 },
+                            },
                             legend: legendPosition,
                             margin: legendPosition.orientation === "h"
-                                ? { t: 40, b: 80 }  // більше місця знизу
+                                ? { t: 40, b: 80 }
                                 : { t: 40, b: 40 },
                             autosize: true,
                             responsive: true,

--- a/src/components/VisualizationComponent/VisualizationBComponents.jsx
+++ b/src/components/VisualizationComponent/VisualizationBComponents.jsx
@@ -1,40 +1,39 @@
 import React, { useEffect, useState } from "react";
 import Plot from "react-plotly.js";
 import s from "./visualizationcomponent.module.css";
+import useWindowDimensions from "../../hooks/useWindowDimensions";
 
 const VisualizationBComponent = ({ data }) => {
 
+    const { width } = useWindowDimensions();
+    const isMobile = width <= 768;
+
     const [colorBarPosition, setColorBarPosition] = useState({
-        orientation: "v",  // вертикальна шкала праворуч
+        orientation: "v",
         x: 1.05,
         y: 0.5,
     });
 
     useEffect(() => {
-        const updateColorbar = () => {
-            const isMobile = window.innerWidth <= 768;
-            setColorBarPosition(isMobile
+        setColorBarPosition(
+            isMobile
                 ? {
                       x: 0.5,
                       y: -0.25,
                       xanchor: "center",
                       len: 0.4,
                       thickness: 15,
-                      orientation: "h"
+                      orientation: "h",
                   }
                 : {
                       x: 1.05,
                       y: 0.5,
                       len: 1,
                       thickness: 15,
-                  });
-        };
-    
-        updateColorbar();
-        window.addEventListener("resize", updateColorbar);
-    
-        return () => window.removeEventListener("resize", updateColorbar);
-    }, []);
+                      orientation: "v",
+                  }
+        );
+    }, [isMobile]);
     
 
     if (!data)
@@ -60,16 +59,32 @@ const VisualizationBComponent = ({ data }) => {
             len: colorBarPosition.len,
             thickness: colorBarPosition.thickness,
             xanchor: colorBarPosition.xanchor || "left",
+            orientation: colorBarPosition.orientation,
         },
                         },
             ]}
             layout={{
-                title: "Теплова карта B-скану",
-                    xaxis: { title: "Позиція (мм)" },
-                    yaxis: { title: "Час (µs)" },
-                    margin: { t: 40, b: 40 },
-                    autosize: true,
-                    responsive: true,
+                title: {
+                    text: "Теплова карта B-скану",
+                    font: { size: isMobile ? 14 : 16 },
+                },
+                xaxis: {
+                    title: {
+                        text: "Позиція (мм)",
+                        font: { size: isMobile ? 12 : 14 },
+                    },
+                    tickfont: { size: isMobile ? 10 : 12 },
+                },
+                yaxis: {
+                    title: {
+                        text: "Час (µs)",
+                        font: { size: isMobile ? 12 : 14 },
+                    },
+                    tickfont: { size: isMobile ? 10 : 12 },
+                },
+                margin: { t: 40, b: 40 },
+                autosize: true,
+                responsive: true,
             }}
         />
         </div>

--- a/src/components/VisualizationComponent/visualizationcomponent.module.css
+++ b/src/components/VisualizationComponent/visualizationcomponent.module.css
@@ -12,17 +12,20 @@
 .plot__wrapper {
     width: 100%;
     max-width: 100%;
-    height: 400px;
+    height: 50vh;
+    min-height: 300px;
 }
 
 @media (max-width: 768px) {
     .plot__wrapper {
-        height: 300px;
+        height: 45vh;
+        min-height: 250px;
     }
 }
 
 @media (max-width: 480px) {
     .plot__wrapper {
-        height: 250px;
+        height: 40vh;
+        min-height: 220px;
     }
 }

--- a/src/hooks/useWindowDimensions.js
+++ b/src/hooks/useWindowDimensions.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return { width, height };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}


### PR DESCRIPTION
## Summary
- add `useWindowDimensions` hook
- make A and B scan charts responsive to screen width
- tune plot wrapper height with viewport units

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529be2fbfc8328a96cdb834ea8af30