### PR TITLE
Improve chart spacing and mobile colorbar

### DIFF
--- a/src/components/VisualizationComponent/VisualizationBComponents.jsx
+++ b/src/components/VisualizationComponent/VisualizationBComponents.jsx
@@ -82,7 +82,10 @@ const VisualizationBComponent = ({ data }) => {
                     },
                     tickfont: { size: isMobile ? 10 : 12 },
                 },
-                margin: { t: 40, b: 40 },
+                margin:
+                    colorBarPosition.orientation === "h"
+                        ? { t: 40, b: 80 }
+                        : { t: 40, b: 40 },
                 autosize: true,
                 responsive: true,
             }}

--- a/src/components/VisualizationComponent/visualizationcomponent.module.css
+++ b/src/components/VisualizationComponent/visualizationcomponent.module.css
@@ -12,20 +12,20 @@
 .plot__wrapper {
     width: 100%;
     max-width: 100%;
-    height: 50vh;
+    height: 70vh;
     min-height: 300px;
 }
 
 @media (max-width: 768px) {
     .plot__wrapper {
-        height: 45vh;
+        height: 60vh;
         min-height: 250px;
     }
 }
 
 @media (max-width: 480px) {
     .plot__wrapper {
-        height: 40vh;
+        height: 55vh;
         min-height: 220px;
     }
 }


### PR DESCRIPTION
## Summary
- enlarge plot wrapper height for more responsive graph area
- adjust mobile colorbar layout margin so horizontal bar doesn't overlap axes

## Testing
- `npm run test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852a689fc308328b2a5cc429fd0c28a