### PR TITLE
Fix B-scan legend layout

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -49,8 +49,7 @@
     flex-direction: column;
     width: 100%;
     max-width: 100%;
-    height: 100%;
-    flex: 1 1 auto;
+    height: auto;
 }
 
 

--- a/src/components/VisualizationComponent/VisualizationBComponents.jsx
+++ b/src/components/VisualizationComponent/VisualizationBComponents.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Plot from "react-plotly.js";
 import s from "./visualizationcomponent.module.css";
 import useWindowDimensions from "../../hooks/useWindowDimensions";
@@ -8,32 +8,13 @@ const VisualizationBComponent = ({ data }) => {
     const { width } = useWindowDimensions();
     const isMobile = width <= 768;
 
-    const [colorBarPosition, setColorBarPosition] = useState({
-        orientation: "v",
+    const colorBarPosition = {
         x: 1.05,
         y: 0.5,
-    });
-
-    useEffect(() => {
-        setColorBarPosition(
-            isMobile
-                ? {
-                      x: 0.5,
-                      y: -0.25,
-                      xanchor: "center",
-                      len: 0.4,
-                      thickness: 15,
-                      orientation: "h",
-                  }
-                : {
-                      x: 1.05,
-                      y: 0.5,
-                      len: 1,
-                      thickness: 15,
-                      orientation: "v",
-                  }
-        );
-    }, [isMobile]);
+        len: 1,
+        thickness: 15,
+        orientation: "v",
+    };
     
 
     if (!data)
@@ -85,10 +66,7 @@ const VisualizationBComponent = ({ data }) => {
                         xanchor: colorBarPosition.xanchor || "left",
                     },
                 },
-                margin:
-                    colorBarPosition.orientation === "h"
-                        ? { t: 40, b: 80 }
-                        : { t: 40, b: 40 },
+                margin: { t: 40, b: 40 },
                 autosize: true,
                 responsive: true,
             }}

--- a/src/components/VisualizationComponent/visualizationcomponent.module.css
+++ b/src/components/VisualizationComponent/visualizationcomponent.module.css
@@ -12,19 +12,20 @@
 .plot__wrapper {
     width: 100%;
     max-width: 100%;
+    height: 70vh;
     min-height: 300px;
-    flex: 1 1 auto;
-    display: flex;
 }
 
 @media (max-width: 768px) {
     .plot__wrapper {
+        height: 60vh;
         min-height: 250px;
     }
 }
 
 @media (max-width: 480px) {
     .plot__wrapper {
+        height: 55vh;
         min-height: 220px;
     }
 }


### PR DESCRIPTION
## Summary
- keep B-scan color bar on the right side for all viewports
- restore fixed heights for visualization wrappers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ac0d6ec88328ab95ac95dc639b56